### PR TITLE
feat: build retro terminal portfolio site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,96 +1,19 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <title></title>
-    <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/adamcantcode/acc-pre-launch/refs/heads/main/favicon.ico">
+  <meta charset="UTF-8">
+  <title>adam cant code :: terminal</title>
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="stylesheet" href="style.css">
 </head>
-<body style="background: #000; margin:0; cursor:none;">
-    <div style="display:flex;flex-direction:column;justify-content:center;align-items:center;height:100vh;width:100vw;position:relative;z-index:100">
-        <h1 style="color: #FFF; font-family: Arial, Helvetica, sans-serif;">don't need to.</h1>
-        <p style="color: #FFF; font-family: Arial, Helvetica, sans-serif;" id="age"></p>
+<body>
+  <div id="terminal">
+    <div id="output"></div>
+    <div class="input-line">
+      <span id="prompt" class="prompt">guest@acc:~$</span>
+      <input type="text" id="command" autofocus autocomplete="off" />
     </div>
-    <div class="overlay"></div>
-
-    <script>
-        document.addEventListener("DOMContentLoaded", () => {
-            const colors = ["#FF5733", "#33FF57", "#3357FF", "#F1C40F", "#8E44AD"];
-            const MAX_CIRCLES = 20;
-            const circles = [];
-            let lastMove = 0;
-
-            document.addEventListener("mousemove", (e) => {
-                const now = performance.now();
-                if (now - lastMove < 50) return; // throttle to ~20fps
-                lastMove = now;
-
-                if (circles.length >= MAX_CIRCLES) {
-                    const oldest = circles.shift();
-                    oldest.remove();
-                }
-
-                const color = colors[(Math.random() * colors.length) | 0];
-                const circle = document.createElement("div");
-                circle.classList.add("cursor-ring");
-                circle.style.left = `${e.pageX - 50}px`;
-                circle.style.top = `${e.pageY - 50}px`;
-                circle.style.backgroundColor = color;
-
-                document.body.appendChild(circle);
-                circles.push(circle);
-
-                setTimeout(() => {
-                    const idx = circles.indexOf(circle);
-                    if (idx !== -1) {
-                        circles.splice(idx, 1);
-                        circle.remove();
-                    }
-                }, 3000);
-            });
-
-            // Age calculator
-            const MS_PER_YEAR = 31556952000;
-            const birthDate = new Date("1995-03-23T00:00:00");
-            const ageEl = document.getElementById("age");
-            const updateAge = () => {
-                const age = (Date.now() - birthDate) / MS_PER_YEAR;
-                ageEl.textContent = age.toFixed(10);
-                requestAnimationFrame(updateAge);
-            };
-            updateAge();
-        });
-    </script>
-
-    <style>
-        .cursor-ring, .overlay {
-            position: absolute;
-            pointer-events: none;
-        }
-        body {
-            margin: 0;
-            overflow: hidden;
-            height: 100vh;
-            background-color: #000;
-            position: relative;
-        }
-        .overlay {
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0, 0, 0, .8);
-            backdrop-filter: blur(25px);
-            z-index: 10;
-        }
-        .cursor-ring {
-            width: 100px;
-            height: 100px;
-            border-radius: 50%;
-            animation: expand 3s ease-out forwards;
-        }
-        @keyframes expand {
-            0% { transform: scale(0); opacity: 1; }
-            100% { transform: scale(5); opacity: 0; }
-        }
-    </style>
+  </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const output = document.getElementById('output');
+  const input = document.getElementById('command');
+  const promptEl = document.getElementById('prompt');
+  let prompt = 'guest@acc:~$';
+  promptEl.textContent = prompt;
+
+  fetch('https://api.ipify.org?format=json')
+    .then(res => res.json())
+    .then(data => {
+      prompt = `${data.ip}:~$`;
+      promptEl.textContent = prompt;
+    })
+    .catch(() => {});
+
+  const commands = {
+    help: `Available commands:\n- about: Who am I\n- projects: Things I've built\n- contact: Get in touch\n- clear: Clear the screen`,
+    about: `Adam Cantcode is a developer who enjoys building playful web experiences with a retro twist.`,
+    projects: `1. Retro Portfolio - the site you're looking at\n2. Another Project - coming soon`,
+    contact: `Email: hello@adamcantcode.com`
+  };
+
+  function print(text) {
+    const line = document.createElement('div');
+    line.textContent = text;
+    output.appendChild(line);
+    output.scrollTop = output.scrollHeight;
+  }
+
+  function runCommand(cmd) {
+    if (cmd === 'clear') {
+      output.innerHTML = '';
+      return;
+    }
+    const response = commands[cmd];
+    if (response) {
+      response.split('\n').forEach(print);
+    } else if (cmd.length > 0) {
+      print(`Command not found: ${cmd}`);
+    }
+  }
+
+  print('Welcome to Adam Cantcode\'s terminal portfolio.');
+  print("Type 'help' to see available commands.");
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      const cmd = input.value.trim();
+      print(`${prompt} ${cmd}`);
+      runCommand(cmd);
+      input.value = '';
+    }
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,53 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+body {
+  background: #000;
+  color: #33ff33;
+  font-family: "Courier New", Courier, monospace;
+  text-shadow: 0 0 5px #33ff33;
+}
+#terminal {
+  box-sizing: border-box;
+  padding: 1rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+#output {
+  flex: 1;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+.input-line {
+  display: flex;
+}
+.prompt {
+  margin-right: 0.5rem;
+}
+#command {
+  background: transparent;
+  border: none;
+  color: #33ff33;
+  flex: 1;
+  font: inherit;
+  outline: none;
+}
+body::after {
+  content: "";
+  pointer-events: none;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.15) 0,
+    rgba(0, 0, 0, 0.15) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  z-index: 9999;
+}


### PR DESCRIPTION
## Summary
- replace previous landing page with a retro terminal-style portfolio
- add green-on-black styling and CRT scanline overlay
- implement simple command parser for about/projects/contact info
- display the visitor's IP address as the terminal prompt

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc624f5c83239d58e066de1b7bce